### PR TITLE
fix(chart): default to <fullName>.<releaseNamespace> for API_URL

### DIFF
--- a/charts/console/templates/deployment.yaml
+++ b/charts/console/templates/deployment.yaml
@@ -32,7 +32,7 @@ spec:
         - name: {{ .Chart.Name }}
           env: 
             - name: API_URL
-              value: {{ .Values.apiURL | default (printf "http://%s-kubefirst-api.%s.svc.cluster.local" (.Release.Name ) (.Release.Namespace ))  }}
+                            value: {{ .Values.apiURL | default (printf "http://%s.%s.svc.cluster.local" ( include "kubefirst-pro-ui.fullname" . ) (.Release.Namespace ))  }}
             - name: KUBEFIRST_VERSION
               value: {{ .Values.global.kubefirstVersion }}
             - name: IS_CLUSTER_ZERO

--- a/charts/console/templates/deployment.yaml
+++ b/charts/console/templates/deployment.yaml
@@ -32,7 +32,7 @@ spec:
         - name: {{ .Chart.Name }}
           env: 
             - name: API_URL
-                            value: {{ .Values.apiURL | default (printf "http://%s.%s.svc.cluster.local" ( include "kubefirst-pro-ui.fullname" . ) (.Release.Namespace ))  }}
+              value: {{ .Values.apiURL | default (printf "http://%s.%s.svc.cluster.local" ( include "console.fullname" . ) (.Release.Namespace ))  }}
             - name: KUBEFIRST_VERSION
               value: {{ .Values.global.kubefirstVersion }}
             - name: IS_CLUSTER_ZERO


### PR DESCRIPTION
## Description
If `API_URL` field is not set in values, infer API URL by appending `Release.Namespace` to output of `console.fullname` template.

## Related Issue(s)
https://github.com/konstructio/gitops-template/pull/836

## How to test
Publish RC and follow `How to test` section in https://github.com/konstructio/gitops-template/pull/836
