### PR TITLE
fix: add helper templates to generate default api service name

### DIFF
--- a/charts/console/templates/_helpers.tpl
+++ b/charts/console/templates/_helpers.tpl
@@ -23,6 +23,10 @@ If release name contains chart name it will be used as a full name.
 {{- end }}
 {{- end }}
 
+{{- define "kubefirst-api.serviceName" -}}
+{{- printf "%s-api" .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
 {{/*
 Create chart name and version as used by the chart label.
 */}}

--- a/charts/console/templates/deployment.yaml
+++ b/charts/console/templates/deployment.yaml
@@ -32,7 +32,7 @@ spec:
         - name: {{ .Chart.Name }}
           env: 
             - name: API_URL
-              value: {{ .Values.apiURL | default (printf "http://%s.%s.svc.cluster.local" ( include "console.fullname" . ) (.Release.Namespace ))  }}
+              value: {{ .Values.apiURL | default (printf "http://%s.%s.svc.cluster.local" ( include "kubefirst-api.serviceName" . ) ( .Release.Namespace ))  }}
             - name: KUBEFIRST_VERSION
               value: {{ .Values.global.kubefirstVersion }}
             - name: IS_CLUSTER_ZERO


### PR DESCRIPTION
## Description
Adds a helper template to render api's service name. This is used as default value if `apiURL` field is not set.

## Related Issue(s)
https://github.com/konstructio/console/pull/521 set `API_URL` env value to console's service name instead of the api's.

## How to test
Use helm template to check API_URL in the deployment defaults to `<releaseName>`-`api`
```
cd charts/console
helm template .
```
