### PR TITLE
fix: use fullname for app.kubernetes.io/name label

### DIFF
--- a/charts/console/templates/_helpers.tpl
+++ b/charts/console/templates/_helpers.tpl
@@ -50,7 +50,7 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 Selector labels
 */}}
 {{- define "console.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "console.name" . }}
+app.kubernetes.io/name: {{ include "console.fullname" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 


### PR DESCRIPTION
## Description
Use fullname template to set `app.kubernetes.io/name` label field. 

## Related Issue(s)
NA

## How to test
<!-- Provide steps to test this PR -->

