### PR TITLE
fix: send api calls with ami type

### DIFF
--- a/containers/ClusterForms/shared/SetupForm.tsx
+++ b/containers/ClusterForms/shared/SetupForm.tsx
@@ -95,6 +95,9 @@ const SetupForm: FunctionComponent = () => {
   const handleRegionChange = useCallback(
     (region: string) => {
       setSelectedRegion(region);
+      if (installType == InstallationType.AWS) {
+        return;
+      }
       // if using google hold off on grabbing instances
       // since it requires the zone as well
 
@@ -110,6 +113,20 @@ const SetupForm: FunctionComponent = () => {
       }
     },
     [dispatch, installType, values],
+  );
+
+  const handleAmiTypeSelect = useCallback(
+    (amiType: string) => {
+      dispatch(
+        getInstanceSizes({
+          installType,
+          region: selectedRegion as string,
+          values,
+          amiType,
+        }),
+      );
+    },
+    [dispatch, installType, selectedRegion, values],
   );
 
   const handleZoneSelect = useCallback(
@@ -228,6 +245,7 @@ const SetupForm: FunctionComponent = () => {
             value: amiType,
           }))}
           defaultValue={AWS_AMI_TYPES[0]}
+          onChange={handleAmiTypeSelect}
         />
       )}
       <ControlledAutocomplete

--- a/package.json
+++ b/package.json
@@ -125,5 +125,6 @@
   "volta": {
     "node": "18.18.0",
     "yarn": "1.22.19"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/package.json
+++ b/package.json
@@ -126,5 +126,4 @@
     "node": "18.18.0",
     "yarn": "1.22.19"
   },
-  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/redux/thunks/api.thunk.ts
+++ b/redux/thunks/api.thunk.ts
@@ -173,12 +173,18 @@ export const getCloudDomains = createAsyncThunk<
 
 export const getInstanceSizes = createAsyncThunk<
   string[],
-  { region: string; installType?: InstallationType; values?: InstallValues; zone?: string },
+  {
+    region: string;
+    installType?: InstallationType;
+    values?: InstallValues;
+    zone?: string;
+    amiType?: string;
+  },
   {
     dispatch: AppDispatch;
     state: RootState;
   }
->('api/getInstanceSizes', async ({ region, installType, values, zone }) => {
+>('api/getInstanceSizes', async ({ region, installType, values, zone, amiType }) => {
   const { instance_sizes } = (
     await axios.post<{ instance_sizes: string[] }>('/api/proxy', {
       url: `/instance-sizes/${installType}`,
@@ -186,6 +192,7 @@ export const getInstanceSizes = createAsyncThunk<
         ...values,
         cloud_region: region,
         cloud_zone: zone,
+        ami_type: amiType,
       },
     })
   ).data;


### PR DESCRIPTION
## Description

Dynamically displays appropriate instance sizes based on the selected AMI type during cluster provisioning.

## How to Test

1.  Clone this repo and `kubefirst-api`.
2.  Checkout `fix-ami-list` in kubefirst-api
3.  Run `bun dev` in *this* repo.
4.  Select AWS and fill in cluster details.
5.  Select an AMI type.
6.  Verify appropriate instance sizes are listed.
